### PR TITLE
Stricter Metabuli parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ readme = {file = "README.md"}
 requires = ["setuptools ~= 63.0", "Cython ~= 0.29.5"]
 build-backend = "setuptools.build_meta"
 
-[tool.ruff]
+[tool.ruff.lint]
 ignore = ["E722", "E501"]
 
 [project.scripts]


### PR DESCRIPTION
The Metabuli report is obstensibly in TSV format, but has been changed in Meta- buli commit a17debb, and may have been changed in previous versions. Therefore, we a) need to handle both versions of the report, depending on what version of Metabuli is used, and b) need to guard against future changes to the format.

This commit rewrites the parser to be stricter.

It also deletes a seemingly unused zero-arg function `metabuli_lineage()`, and the unused constant METABULI_LINEAGE.