### PR TITLE
Track data/clades.tsv as part of the package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,9 @@ filterwarnings = [
     "error",
     "ignore::UserWarning",
 ]
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+[tool.setuptools.package-data]
+"taxconverter" = ["data/clades.tsv"]


### PR DESCRIPTION
This change makes sure the clades.tsv is included when installing taxconverter. By default, Python's tooling will search the source directory for relevant files and exclude all others.
Here, explicitly add package data.

This makes taxconverter work when installed with pypi, or in a virtual environment.