### PR TITLE
Bug fix metabuli 

### DIFF
--- a/taxconverter/__main__.py
+++ b/taxconverter/__main__.py
@@ -219,10 +219,6 @@ def metabuli_from_iter(lines: Iterable[str]) -> dict[int, str]:
         if stripped_clade in clade_to_lineage:
             raise ValueError(f'Duplicate clade seen: "{stripped_clade}"')
 
-        # May or may not appear in output, but we need to ignore this if it's there.
-        if stripped_clade == "unclassified":
-            continue
-
         if ";" in stripped_clade:
             raise ValueError(
                 f'Semicolon cannot appear in clade name "{stripped_clade}"'

--- a/taxconverter/__main__.py
+++ b/taxconverter/__main__.py
@@ -386,6 +386,7 @@ def main():
         df_clas[LINEAGE_COL] = tax_ids.map(map_lineage)
         df_clas[LINEAGE_COL] = df_clas[LINEAGE_COL].replace("unclassified", "")
         df_clas[LINEAGE_COL] = df_clas[LINEAGE_COL].str.replace('root;', '', regex=False)
+        df_clas[LINEAGE_COL] = df_clas[LINEAGE_COL].str.replace('root', '', regex=False)
         df_clas[SEQ_COL] = df_clas[1]
         df_clas_tax = df_clas[[SEQ_COL, LINEAGE_COL]]
         elapsed = round(time.time() - begintime, 2)


### PR DESCRIPTION
1) 
Metabuli right now when parsing *.metabuli_report.tsv ignores the line
in the report: 
```1.1064  2133    2133    no rank 0       unclassified```
https://github.com/RasmussenLab/taxconverter/commit/1c481dd8aa4088e28f6e0f3ce2f2b8e1559db99e#diff-c12ced2ed0f1a7d4cc2c4383e3ca873333597847606c58042ab48b0f71cf4380L222-L224

This means that 0 mapping to unclassified is not added to map_linage -
and the error check on line 378 fails if some contigs are not assigned a taxid: https://github.com/RasmussenLab/taxconverter/commit/1c481dd8aa4088e28f6e0f3ce2f2b8e1559db99e#diff-c12ced2ed0f1a7d4cc2c4383e3ca873333597847606c58042ab48b0f71cf4380R378-R384

2)
Some contigs maps to just root. These are not changed to "" in:
https://github.com/RasmussenLab/taxconverter/compare/bug_fix_metabuli_crash#diff-c12ced2ed0f1a7d4cc2c4383e3ca873333597847606c58042ab48b0f71cf4380R388
I think changing them to "" is correct behaviour

I checked the results against my own script and now they produce similar output ( for better or worse ;) ) 
